### PR TITLE
Added DI for CheepRepository and AuthorRepostory #49

### DIFF
--- a/Chirp.Razor/Program.cs
+++ b/Chirp.Razor/Program.cs
@@ -1,4 +1,5 @@
 using Chirp.Razor.data;
+using Chirp.Razor.Repositories;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -9,7 +10,9 @@ builder.Services.AddDbContext<ChirpDBContext>(options => options.UseSqlite(conne
 
 // Add services to the container.
 builder.Services.AddRazorPages();
-builder.Services.AddSingleton<ICheepService, CheepService>();
+builder.Services.AddScoped<ICheepService, CheepService>();
+builder.Services.AddScoped<IAuthorRepository, AuthorRepository>();
+builder.Services.AddScoped<ICheepRepository, CheepRepository>();
 
 var app = builder.Build();
 


### PR DESCRIPTION
DI considerations:
Everything (ChirpDBContext, CheepService, AuthorRepository and CheepRepository) have a timeline set to scoped, so "within a scope, all requests for a service give you the same object. For different scopes, you get different objects. " - ASP.NET Core in Action (the course book). So within each web request we have the same instances.

They are not set to transistent or singleton because transistent creates new instance for each request which might end up breaking transactional or/and data consistency and singleton is not thread-safe with DB contexts