### PR TITLE
44 61d seeding the database with example data testing

### DIFF
--- a/tests/Chirp.Infrastructure.Tests/Data/DbInitializerTest.cs
+++ b/tests/Chirp.Infrastructure.Tests/Data/DbInitializerTest.cs
@@ -106,4 +106,29 @@ public class DbInitializerTest : IDisposable
         Assert.DoesNotContain(cheeps, cheep => cheep.Text == "It is he, then?");
         
     }
+
+    [Fact]
+    public void TestDbInitializerDoesNotDoubleSeededDataIfCalledTwice()
+    {
+        using var context = CreateDbContext();
+        context.Database.EnsureCreated();
+        bool isDatabaseEmpty = !context.Authors.Any() && !context.Cheeps.Any();
+        Assert.True(isDatabaseEmpty);
+        
+        DbInitializer.SeedDatabase(context);
+        
+        isDatabaseEmpty = !context.Authors.Any() && !context.Cheeps.Any();
+        Assert.False(isDatabaseEmpty);
+        HashSet<Author> authors = context.Authors.ToHashSet();
+        Assert.Equal(12, authors.Count);
+        HashSet<Cheep> cheeps = context.Cheeps.ToHashSet();
+        Assert.Equal(657, cheeps.Count);
+        
+        DbInitializer.SeedDatabase(context);
+        authors = context.Authors.ToHashSet();
+        Assert.Equal(12, authors.Count);
+        cheeps = context.Cheeps.ToHashSet();
+        Assert.Equal(657, cheeps.Count);
+        
+    }
 }


### PR DESCRIPTION
This pull request contains tests for the DBInitializer to check that it works as intended (issue #44)
I have tested that: 

- If a database is empty and the program calls DbInitializer.SeedDatabase, it seeds the database with the correct information
- If a database is not empty and DbInitializer.SeedDatabase is called, then it will not seed the database either by override or adding. 
- If DbInitializer.SeedDatabase is called twice (first time on an empty database) it does not duplicate the data. 