### PR TITLE
128 how to run test suite locally

### DIFF
--- a/docs/report.md
+++ b/docs/report.md
@@ -38,30 +38,26 @@ Here comes a description of our domain model.
 ### Prerequisites
 1. Clone the repository. Follow the steps outlined in the previous section.
 2. Install Playwright, which is required for the integration tests.
-See the official documentation [here](https://playwright.dev/docs/intro) or if you are
-on Windows, complete the following steps:
-    1. Open a terminal in the project root folder.
-    2. Run the following commands:
-       ```
-       cd .\tests\Chirp.Web.Tests\
-       dotnet restore
-       pwsh bin/Debug/net8.0/playwright.ps1 install
-       ```
-       _Tip: If the `pwsh` command does not work, your powershell version might be outdated._
+Follow the official documentation [here](https://playwright.dev/docs/intro) - or if you are
+on Windows, install by running the following commands from the project root:
+    ```
+    cd .\tests\Chirp.Web.Tests\
+    dotnet restore
+    pwsh bin/Debug/net8.0/playwright.ps1 install
+    ```
+    _Tip: If the `pwsh` command does not work, your powershell version might be outdated._
 
 ### Execute tests
-To run the tests...
-
-Then, simply navigate to the project root folder in a terminal and run `dotnet test`.
+To run the tests, open a terminal in the project root and run `dotnet test`.
 This should run the entire test suite.
 
-### Test suite describtion
+### Test suite description
 The test suite consists of unit tests pertaining to the code found in
 `Chirp.Core` and `Chirp.Infrastructure`.
 These ensure that the internal processing of the application's functionality are tested
 thoroughly and individually.
 Besides these unit tests the test suite also contains integration tests found in `Chirp.Web`.
-These include both end-to-end tests of larger scenarios as well as tests of individual UI
+These include both end-to-end tests of larger scenarios and tests of individual UI
 elements.
 
 # Ethics


### PR DESCRIPTION
As per https://github.com/ITU-BDSA2025-GROUP8/Chirp/issues/128

@tropaadigselv can you please try the playwright windows install instructions i have written? 

@everyone do you think we absolutely need explicit instructions for how to install playwright on mac? I personally don't think so given that we now link to playwright's own instructions. And even then i won't be able to write them, so the task would fall on someone with a mac...